### PR TITLE
Feat: print env when inside docker container

### DIFF
--- a/docker.env
+++ b/docker.env
@@ -1,0 +1,6 @@
+#LS_JAVA_OPTS="-Xms256m -Xmx256m -XX:MaxMetaspaceSize=256m"
+# Common LS options (can be overridden from ENV e.g. in .travis.yml) :
+# - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
+# - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
+# - `-v -W1` print JRuby version but do not go verbose
+JRUBY_OPTS=-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/unit/docker.env
+++ b/unit/docker.env
@@ -1,6 +1,1 @@
-#LS_JAVA_OPTS="-Xms256m -Xmx256m -XX:MaxMetaspaceSize=256m"
-# Common LS options (can be overridden from ENV e.g. in .travis.yml) :
-# - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
-# - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
-# - `-v -W1` print JRuby version but do not go verbose
-JRUBY_OPTS=-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
+../docker.env

--- a/unit/run.sh
+++ b/unit/run.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-
 # This is intended to be run inside the docker container as the command of the docker-compose.
+
+env
+
 set -ex
 
 jruby -rbundler/setup -S rspec -fd


### PR DESCRIPTION
... missed this one -> quite useful when debugging CI issues
\+ also moved `docker.env` -> already shared on grok plugin