### PR TITLE
drop testing against LS 5.x

### DIFF
--- a/.travis.yml.example
+++ b/.travis.yml.example
@@ -1,0 +1,3 @@
+---
+version: ~> 1.0
+import: logstash-plugins/.ci:unit.travis.yml@master

--- a/unit.travis.yml
+++ b/unit.travis.yml
@@ -10,7 +10,6 @@ sudo: required
 language: minimal
 matrix:
   include:
-  - env: ELASTIC_STACK_VERSION=5.x
   - env: ELASTIC_STACK_VERSION=6.x
   - env: ELASTIC_STACK_VERSION=7.x
   - env: ELASTIC_STACK_VERSION=7.x SNAPSHOT=true

--- a/unit.travis.yml
+++ b/unit.travis.yml
@@ -1,9 +1,9 @@
-# Sample file for running tests with Travis CI.
+# Shared (unit tests) build configuration for Travis CI.
 #
-# NOTE: you will need to copy this file to your plugin root!
-#
-# Doing a `ln --symbolic ci/.travis.yml` won't work as Travis expects
-# to read the *.travis.yml* file BEFORE it initializes git submodules.
+# Setup your .travis.yml to import this file e.g. :
+#    ---
+#    version: ~> 1.0
+#    import: logstash-plugins/.ci:unit.travis.yml@master
 #
 ---
 sudo: required


### PR DESCRIPTION
also renamed config to `unit.travis.yml` as we will want to import - thus name should be clear:
```yaml
---
version: ~> 1.0
import: logstash-plugins/.ci:unit.travis.yml@master
```