### PR TITLE
ensure rake vendor runs during setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ RUN gem install bundler -v '< 2'
 WORKDIR /usr/share/plugins/plugin
 RUN bundle install --with test ci
 COPY --chown=logstash:logstash . /usr/share/plugins/plugin
+RUN bundle exec rake vendor
 RUN .ci/setup.sh


### PR DESCRIPTION
devutils ensures all plugins have the rake vendor task even if it's a no-op.
And for many plugins, this task is needed to fetch or compile jars.