### PR TITLE
allow the use of a extended docker-compose override file

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -7,4 +7,5 @@ CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 cd .ci
 
+# docker will look for: "./docker-compose.yml" (and "./docker-compose.override.yml")
 docker-compose up --exit-code-from logstash

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -5,4 +5,6 @@ set -ex
 
 CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-docker-compose -f $CURRENT_DIR/docker-compose.yml up --exit-code-from logstash
+cd .ci
+
+docker-compose up --exit-code-from logstash

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -57,9 +57,9 @@ if [ -f Gemfile.lock ]; then
     rm Gemfile.lock
 fi
 
-CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}") # e.g. "ci/unit"
+CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-docker-compose -f "$CURRENT_DIR/docker-compose.yml" down
-docker-compose -f "$CURRENT_DIR/docker-compose.yml" build logstash
+cd .ci
 
-#docker-compose -f "$CURRENT_DIR/docker-compose.yml" up --exit-code-from logstash --force-recreate
+docker-compose down
+docker-compose build


### PR DESCRIPTION
by not specifying the -f flag in docker compose, we let it look for
two files: "./docker-compose.yml" and "./docker-compose.override.yml"

this is useful for plugins that need to add new services or override
settings of the logstash service.

See more about this feature in https://docs.docker.com/compose/extends/#understanding-multiple-compose-files

An example of building on top of this capability can be seen this jdbc integration PR: https://github.com/logstash-plugins/logstash-integration-jdbc/pull/24/files#diff-2f48dc62f092d9cd242c1514bfc5e09b