### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 ARG ELASTIC_STACK_VERSION
 FROM docker.elastic.co/logstash/logstash:$ELASTIC_STACK_VERSION
 USER logstash
-COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
-COPY --chown=logstash:logstash *.gemspec VERSION* version* /usr/share/plugins/plugin/
 RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin"
 ENV LOGSTASH_SOURCE="1"
@@ -14,6 +12,8 @@ ENV DISTRIBUTION=$DISTRIBUTION
 ARG INTEGRATION
 ENV INTEGRATION=$INTEGRATION
 RUN gem install bundler -v '< 2'
+COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
+COPY --chown=logstash:logstash *.gemspec VERSION* version* /usr/share/plugins/plugin/
 WORKDIR /usr/share/plugins/plugin
 RUN bundle install --with test ci
 COPY --chown=logstash:logstash . /usr/share/plugins/plugin


### PR DESCRIPTION
minimize the amount of work done in building the docker image across different plugins.

If you're testing multiple plugins locally on your machine, this should reduce the time it takes to build the image