### PR TITLE
Define JAVA_HOME to point to bundled JDK

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -8,4 +8,8 @@ CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
 cd .ci
 
 # docker will look for: "./docker-compose.yml" (and "./docker-compose.override.yml")
-docker-compose up --exit-code-from logstash
+if [[ "$ELASTIC_STACK_RETRIEVED_VERSION" = "8.0.0"* ]]; then
+  docker-compose --end-file docker_jdk_bundled.env up --exit-code-from logstash 
+else
+  docker-compose up --exit-code-from logstash
+fi

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -36,6 +36,7 @@ else
   DISTRIBUTION_SUFFIX=""
 fi
 
+export ELASTIC_STACK_RETRIEVED_VERSION
 echo "Testing against version: $ELASTIC_STACK_VERSION (distribution: ${DISTRIBUTION:-"default"})"
 
 if [[ "$ELASTIC_STACK_VERSION" = *"-SNAPSHOT" ]]; then

--- a/docker_jdk_bundled.env
+++ b/docker_jdk_bundled.env
@@ -1,0 +1,8 @@
+#LS_JAVA_OPTS="-Xms256m -Xmx256m -XX:MaxMetaspaceSize=256m"
+# Common LS options (can be overridden from ENV e.g. in .travis.yml) :
+# - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
+# - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
+# - `-v -W1` print JRuby version but do not go verbose
+JAVA_HOME=/usr/share/logstash/jdk/
+PATH=$PATH:/usr/share/logstash/jdk/bin/
+JRUBY_OPTS=-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1


### PR DESCRIPTION
Define JAVA_HOME to point to bundled JDK (in case the LS Docker image has it)

Starting with JDK bundled Docker images of Logstash,the java provided by the system has been removed in favor of the bundled one.
Without JAVA_HOME JRuby bootstrap script is not albe to identify a JVM to run the RSpec.