### PR TITLE
Fix: locate `java` for 8.0 (SNAPSHOT) images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ USER logstash
 COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
 COPY --chown=logstash:logstash *.gemspec VERSION* version* /usr/share/plugins/plugin/
 RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml
-ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin"
+# NOTE: since 8.0 JDK is bundled as part of the LS distribution under $LS_HOME/jdk
+ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/jdk/bin"
 ENV LOGSTASH_SOURCE="1"
 ENV ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
 # DISTRIBUTION="default" (by default) or "oss"


### PR DESCRIPTION
currently, for 8.0-SNAPSHOT images, `docker-setup.sh` fails: 

`/usr/share/logstash/vendor/jruby/bin/jruby: line 446: exec: java: not found`

due the image no longer installing a global JDK but instead using a bundled one under `$LS_HOME/jdk`