### PR TITLE
Feat: upgrade linux dist image used for tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,5 @@ services:
     env_file: docker.env
     environment:
       - SPEC_OPTS
-      - LOGGER_LEVEL # devutils reads the ENV and sets LS logging
+      - LOG_LEVEL # devutils (>= 2.0.4) reads the ENV and sets LS logging
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,5 @@ services:
     env_file: docker.env
     environment:
       - SPEC_OPTS
-      #- JRUBY_OPTS
+      - LOGGER_LEVEL # devutils reads the ENV and sets LS logging
     tty: true

--- a/travis/defaults.yml
+++ b/travis/defaults.yml
@@ -1,7 +1,3 @@
 os: linux
-language: ruby
-services: docker
-addons:
-  apt:
-    packages:
-    - docker-ce
+dist: focal # 20.04 LTS
+language: minimal # Docker installed


### PR DESCRIPTION
While setting up [twitter input integration testing](https://github.com/logstash-plugins/logstash-input-twitter/pull/70) ended up doing a lot of overrides for *.ci*.
I think we could update the dist used globally to Ubuntu's current LTS, let me know if there are concerns.