### PR TITLE
Docker image fixes arch and oss

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG ELASTIC_STACK_VERSION
-FROM docker.elastic.co/logstash/logstash:$ELASTIC_STACK_VERSION
+ARG DISTRIBUTION_SUFFIX
+FROM docker.elastic.co/logstash/logstash${DISTRIBUTION_SUFFIX}:${ELASTIC_STACK_VERSION}
 USER logstash
 COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
 COPY --chown=logstash:logstash *.gemspec VERSION* version* /usr/share/plugins/plugin/

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -30,11 +30,11 @@ if [[ "$ELASTIC_STACK_RETRIEVED_VERSION" != "null" ]]; then
   export ELASTIC_STACK_VERSION=$ELASTIC_STACK_RETRIEVED_VERSION
 fi
 
-if [[ "$DISTRIBUTION" = "oss" ]]; then
-  DISTRIBUTION_SUFFIX="-oss"
-else
-  DISTRIBUTION_SUFFIX=""
-fi
+case "${DISTRIBUTION}" in
+  default) DISTRIBUTION_SUFFIX="" ;; # empty string when explicit "default" is given
+        *) DISTRIBUTION_SUFFIX="${DISTRIBUTION/*/-}${DISTRIBUTION}" ;;
+esac
+export DISTRIBUTION_SUFFIX
 
 echo "Testing against version: $ELASTIC_STACK_VERSION (distribution: ${DISTRIBUTION:-"default"})"
 


### PR DESCRIPTION
 - ensure `DISTRIBUTION_SUFFIX` propagates so that we base our image off the correct upstream image
 - handle arch-specific docker images coming in Logstash 8.