### PR TITLE
Feat: made .ci/setup.sh hook usable for updating system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN usermod -aG wheel logstash && \
     echo "logstash ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/logstash && \
     chmod 0440 /etc/sudoers.d/logstash
 USER logstash
-COPY --chown=logstash:logstash . /usr/share/plugins/plugin/
+# whole . plugin code could be copied here but we only do that later, after bundle install,
+# to speedup incremental image builds (locally one's mostly changing lib/ and spec/ files)
+COPY --chown=logstash:logstash Gemfile *.gemspec VERSION* version* /usr/share/plugins/plugin/
 RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml
 # NOTE: since 8.0 JDK is bundled as part of the LS distribution under $LS_HOME/jdk
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/jdk/bin"
@@ -25,4 +27,5 @@ WORKDIR /usr/share/plugins/plugin
 RUN .ci/setup.sh
 RUN gem install bundler -v '< 2'
 RUN bundle install --with test ci
+COPY --chown=logstash:logstash . /usr/share/plugins/plugin/
 RUN bundle exec rake vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ ENV DISTRIBUTION=$DISTRIBUTION
 # INTEGRATION="true" while integration testing (false-y by default)
 ARG INTEGRATION
 ENV INTEGRATION=$INTEGRATION
-RUN gem install bundler -v '< 2'
 WORKDIR /usr/share/plugins/plugin
+RUN .ci/setup.sh
+RUN gem install bundler -v '< 2'
 RUN bundle install --with test ci
 RUN bundle exec rake vendor
-RUN .ci/setup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ ARG ELASTIC_STACK_VERSION
 ARG DISTRIBUTION_SUFFIX
 FROM docker.elastic.co/logstash/logstash${DISTRIBUTION_SUFFIX}:${ELASTIC_STACK_VERSION}
 USER logstash
-COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
-COPY --chown=logstash:logstash *.gemspec VERSION* version* /usr/share/plugins/plugin/
+COPY --chown=logstash:logstash . /usr/share/plugins/plugin/
 RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml
 # NOTE: since 8.0 JDK is bundled as part of the LS distribution under $LS_HOME/jdk
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/jdk/bin"
@@ -18,6 +17,5 @@ ENV INTEGRATION=$INTEGRATION
 RUN gem install bundler -v '< 2'
 WORKDIR /usr/share/plugins/plugin
 RUN bundle install --with test ci
-COPY --chown=logstash:logstash . /usr/share/plugins/plugin
 RUN bundle exec rake vendor
 RUN .ci/setup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN usermod -aG wheel logstash && \
     echo "logstash ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/logstash && \
     chmod 0440 /etc/sudoers.d/logstash
 USER logstash
+# whole . plugin code could be copied here but we only do that after bundle install,
+# to speedup incremental builds (locally one's mostly changing lib/ and spec/ files)
+COPY --chown=logstash:logstash Gemfile *.gemspec VERSION* version* /usr/share/plugins/plugin/
 RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml
 # NOTE: since 8.0 JDK is bundled as part of the LS distribution under $LS_HOME/jdk
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/jdk/bin"
@@ -24,9 +27,6 @@ RUN gem install bundler -v '< 2'
 WORKDIR /usr/share/plugins/plugin
 COPY --chown=logstash:logstash .ci/* /usr/share/plugins/plugin/.ci/
 RUN .ci/setup.sh
-# whole . plugin code could be copied here but we only do that after bundle install,
-# to speedup incremental builds (locally one's mostly changing lib/ and spec/ files)
-COPY --chown=logstash:logstash Gemfile *.gemspec VERSION* version* /usr/share/plugins/plugin/
 RUN bundle install --with test ci
 COPY --chown=logstash:logstash . /usr/share/plugins/plugin/
 RUN bundle exec rake vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 ARG ELASTIC_STACK_VERSION
 ARG DISTRIBUTION_SUFFIX
 FROM docker.elastic.co/logstash/logstash${DISTRIBUTION_SUFFIX}:${ELASTIC_STACK_VERSION}
+# install and enable password-less sudo for logstash user
+# allows modifying the system inside the container (using the .ci/setup.sh hook)
+USER root
+RUN yum install -y sudo
+RUN usermod -aG wheel logstash && \
+    echo "logstash ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/logstash && \
+    chmod 0440 /etc/sudoers.d/logstash
 USER logstash
 COPY --chown=logstash:logstash . /usr/share/plugins/plugin/
 RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ RUN usermod -aG wheel logstash && \
     echo "logstash ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/logstash && \
     chmod 0440 /etc/sudoers.d/logstash
 USER logstash
-# whole . plugin code could be copied here but we only do that later, after bundle install,
-# to speedup incremental image builds (locally one's mostly changing lib/ and spec/ files)
-COPY --chown=logstash:logstash Gemfile *.gemspec VERSION* version* /usr/share/plugins/plugin/
 RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml
 # NOTE: since 8.0 JDK is bundled as part of the LS distribution under $LS_HOME/jdk
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/jdk/bin"
@@ -23,9 +20,13 @@ ENV DISTRIBUTION=$DISTRIBUTION
 # INTEGRATION="true" while integration testing (false-y by default)
 ARG INTEGRATION
 ENV INTEGRATION=$INTEGRATION
-WORKDIR /usr/share/plugins/plugin
-RUN .ci/setup.sh
 RUN gem install bundler -v '< 2'
+WORKDIR /usr/share/plugins/plugin
+COPY --chown=logstash:logstash .ci/* /usr/share/plugins/plugin/.ci/
+RUN .ci/setup.sh
+# whole . plugin code could be copied here but we only do that after bundle install,
+# to speedup incremental builds (locally one's mostly changing lib/ and spec/ files)
+COPY --chown=logstash:logstash Gemfile *.gemspec VERSION* version* /usr/share/plugins/plugin/
 RUN bundle install --with test ci
 COPY --chown=logstash:logstash . /usr/share/plugins/plugin/
 RUN bundle exec rake vendor


### PR DESCRIPTION
there's a minor use-case I am after here: when development involves multiple plugins it's desirable to use `git: ...` dependencies in the *Gemfile* to cross test changes between plugins (e.g. in a draft PR).

For that to work one needs to install `git` for bundler to be able to fetch the code.
The only way to do so, before this PR, is to provide a complete copy of a `.ci/Dockefile` with:
```
+ USER root
+ RUN yum install -y git
+ USER logstash
```
... before reaching the `RUN bundle install --with test ci` [step](https://github.com/logstash-plugins/.ci/blob/8ab5f0f9c4db958a4059711216e234617e1cb2c6/Dockerfile#L20)

The changes here allow for overriding the `.ci/setup.sh` hook (which will now execute before `bundle install && rake vendor`) which would simply contain a `sudo yum install -y git`. 

The default `.ci/setup.sh` script is a noop and haven't been leveraged, with these changes might prove useful for doing additional package installs or other root level adjustments before running tests.

---

sample use-case where this PR would eliminate having to pull in a `Dockerfile`: https://github.com/logstash-plugins/logstash-filter-grok/pull/162/files#diff-fd0c8401badda82156f9e7bd621fa3a0e586d8128e4a80af17c7cbff70bee11e