### PR TITLE
Backport #28 to 1.x: Update build matrix to pull from 8.x

### DIFF
--- a/travis/matrix.yml
+++ b/travis/matrix.yml
@@ -15,10 +15,11 @@ stages:
 
 env:
   jobs:
+    - ELASTIC_STACK_VERSION=8.x
     - ELASTIC_STACK_VERSION=7.x
     - ELASTIC_STACK_VERSION=6.x
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.0.0-SNAPSHOT
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=7.x-SNAPSHOT
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.x
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=7.x
 
 jobs:
 - stage: Performance
@@ -28,4 +29,6 @@ jobs:
 - <<: *_performance
   env: ELASTIC_STACK_VERSION=7.x
 - <<: *_performance
-  env: SNAPSHOT=true ELASTIC_STACK_VERSION=8.0.0-SNAPSHOT
+  env: ELASTIC_STACK_VERSION=8.x
+- <<: *_performance
+  env: SNAPSHOT=true ELASTIC_STACK_VERSION=8.x


### PR DESCRIPTION
Backport #28 to 1.x branch. Original message:

Also pull snapshot versions from `logstash_releases.json` instead of
specifying explicitly
