### PR TITLE
start running Java test along side Ruby (rspec) ones

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: .ci/run.sh
     env_file: docker.env
     environment:
-      - SPEC_OPTS
+      - SPEC_OPTS="${SPEC_OPTS:--fd}"
       - LOG_LEVEL # devutils (>= 2.0.4) reads the ENV and sets LS logging
       - CI # CI=true in Travis-CI
       - TRAVIS # TRAVIS=true in Travis-CI

--- a/run.sh
+++ b/run.sh
@@ -5,4 +5,4 @@ env
 
 set -ex
 
-jruby -rbundler/setup -S rspec -fd
+jruby -rbundler/setup -S rake test


### PR DESCRIPTION
Motivation: some of the logstash plugins have useful Java tests e.g. [DLQ input](https://github.com/logstash-plugins/logstash-input-dead_letter_queue/tree/main/src/test/java/org/logstash/input) or the [user-agent filter](https://github.com/logstash-plugins/logstash-filter-useragent/tree/main/src/test/java/org/logstash/uaparser)
For now, Java tests were not run by default. This PR attempts to change that and run `gradlew test` along side `rspec`.

Depends on having a (default) `rake test` https://github.com/elastic/logstash-devutils/pull/96
On most plugins (wout Java sources) `rake test` will simply launch `rspec` with it's defaults.
However, if a `gradlew` file is detected in cwd than `rake test` will first attempt to run `./gradlew test`.