### PR TITLE
limit memory tests run (on CI) to ~1g

### DIFF
--- a/docker.env
+++ b/docker.env
@@ -3,4 +3,4 @@
 # - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
 # - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
 # - `-v -W1` print JRuby version but do not go verbose
-JRUBY_OPTS=-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
+JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1


### PR DESCRIPTION
currently tests use whatever the machine has (the JVM uses as defaults), 
on Travis: `-XX:InitialHeapSize=130380544 -XX:MaxHeapSize=2086088704`