### PR TITLE
stop testing plugins against 6.x

### DIFF
--- a/travis/matrix.yml
+++ b/travis/matrix.yml
@@ -17,7 +17,6 @@ env:
   jobs:
     - ELASTIC_STACK_VERSION=8.x
     - ELASTIC_STACK_VERSION=7.x
-    - ELASTIC_STACK_VERSION=6.x
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.x
     - SNAPSHOT=true ELASTIC_STACK_VERSION=7.x
 
@@ -25,8 +24,6 @@ jobs:
 - stage: Performance
   name: Performance Base-Line
   <<: *_performance
-  env: ELASTIC_STACK_VERSION=6.x
-- <<: *_performance
   env: ELASTIC_STACK_VERSION=7.x
 - <<: *_performance
   env: ELASTIC_STACK_VERSION=8.x


### PR DESCRIPTION
Has been discussed before, given Logstash:
- 6.8.x EOLed 2022-02-10
- 8.x is the current stable line
- 7.17 is is maintenance mode

