### PR TITLE
Add support for Logstash distributions using JDK17 as default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         - DISTRIBUTION=${DISTRIBUTION:-default}
         #- INTEGRATION=false
     command: .ci/run.sh
-    env_file: docker.env
+    env_file: ${DOCKER_ENV:-docker.env}
     environment:
       - SPEC_OPTS
       - LOG_LEVEL # devutils (>= 2.0.4) reads the ENV and sets LS logging

--- a/dockerjdk17.env
+++ b/dockerjdk17.env
@@ -1,0 +1,8 @@
+#LS_JAVA_OPTS="-Xms256m -Xmx256m -XX:MaxMetaspaceSize=256m"
+# Common LS options (can be overridden from ENV e.g. in .travis.yml) :
+# - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
+# - set add-exports and add-opens to those required to run logstash under jdk17
+# - use default garbage collection G1GC 
+# - `-v -W1` print JRuby version but do not go verbose
+JRUBY_OPTS=-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED -J--add-opens=java.base/java.security=ALL-UNNAMED -J--add-opens=java.base/java.io=ALL-UNNAMED -J--add-opens=java.base/java.nio.channels=ALL-UNNAMED -J--add-opens=java.base/sun.nio.ch=ALL-UNNAMED -J--add-opens=java.management/sun.management=ALL-UNNAMED -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+PrintCommandLineFlags -v -W1
+

--- a/travis/matrix.yml
+++ b/travis/matrix.yml
@@ -15,9 +15,9 @@ stages:
 
 env:
   jobs:
-    - ELASTIC_STACK_VERSION=8.x
+    - ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk17.env
     - ELASTIC_STACK_VERSION=7.x
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.x
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk17.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=7.x
 
 jobs:
@@ -26,6 +26,6 @@ jobs:
   <<: *_performance
   env: ELASTIC_STACK_VERSION=7.x
 - <<: *_performance
-  env: ELASTIC_STACK_VERSION=8.x
+  env: ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk17.env
 - <<: *_performance
-  env: SNAPSHOT=true ELASTIC_STACK_VERSION=8.x
+  env: SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk17.env


### PR DESCRIPTION
Adds a new docker.env file to set the appropriate Java startup options required to run
tests under JDK17

