### PR TITLE
fix jruby's bundler for test

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,4 +5,4 @@ env
 
 set -ex
 
-jruby -rbundler/setup -S rspec -fd
+bundle exec jruby -rbundler/setup -S rspec -fd

--- a/run.sh
+++ b/run.sh
@@ -5,4 +5,4 @@ env
 
 set -ex
 
-bundle exec jruby -rbundler/setup -S rspec -fd
+bundle exec rspec --format=documentation


### PR DESCRIPTION
Fix: [#14800](https://github.com/elastic/logstash/issues/14800)

<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## What does this PR do?

Use the bundler in `/vendor/bundle/jruby/2.6.0/bin/bundle` instead of `/vendor/jruby/bin/bundle` to run test, as Logstash doesn't package the latter in artifacts in https://github.com/elastic/logstash/pull/14667

