### PR TITLE
fix jruby bundler

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,4 +5,4 @@ env
 
 set -ex
 
-jruby -rbundler/setup -S rake test
+bundle exec rake test


### PR DESCRIPTION
Fix: https://github.com/elastic/logstash/issues/14800
Relate: https://github.com/logstash-plugins/.ci/pull/44

CI points to [1.x](https://github.com/logstash-plugins/.ci/blob/main/travis/exec.yml#L2). Tests are still failing.
This PR fixes the command in `1.x` branch