### PR TITLE
Fix passing ELASTIC_STACK_VERSION and SNAPSHOT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,4 +19,6 @@ services:
       - LOG_LEVEL # devutils (>= 2.0.4) reads the ENV and sets LS logging
       - CI # CI=true in Travis-CI
       - TRAVIS # TRAVIS=true in Travis-CI
+      - ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
+      - SNAPSHOT=${SNAPSHOT:-false}
     tty: true


### PR DESCRIPTION
ELASTIC_STACK_VERSION and SNAPSHOT are empty inside the container due to the usage of `env_file` in docker-compose.yml. According to [env variables precedence](https://docs.docker.com/compose/envvars-precedence/), env variables are resolved in the order of command line `--env`, compose.yaml environment key, compsoe.yaml env_file key and ENV directive. It does not inherit shell env.

The PR pass `ELASTIC_STACK_VERSION`and `SNAPSHOT` that is referenced in [matrix.yaml](https://github.com/logstash-plugins/.ci/blob/main/travis/matrix.yml)

Fixed: [14824](https://github.com/elastic/logstash/issues/14824)