### PR TITLE
[Backport] Add MacOS throubleshooting section (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,22 @@ import:
 
 If the plugin follows conventions and (unit) tests all run using `rspec`, simply
 place your own shell scripts in the .ci folder
+
+
+## Mac OS throubleshooting
+In some circumstances on MacOS, Rosetta2 could kicks it and generate an error related to QEMU not able to run some x86 code, for example:
+```
+ci-logstash-1  | Failed (Expected: 10000 got: 0, execution output:
+ci-logstash-1  |  qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
+ci-logstash-1  | ). Sleeping for 2.0
+```
+
+In such cases set and export `DOCKER_DEFAULT_PLATFORM` environment variable:
+```
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+and then rebuild the image:
+```
+.ci/docker-setup.sh && .ci/docker-run.sh
+```


### PR DESCRIPTION
Described the usage of DOCKER_DEFAULT_PLATFORM in case Rosetta2 kicks in and create problems when running integration dockerized test harness on plugin.

