### PR TITLE
Add Elasticsearch Treeign Arg to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG ELASTIC_STACK_VERSION
+ARG ELASTICSEARCH_TREEISH
 ARG DISTRIBUTION_SUFFIX
 FROM docker.elastic.co/logstash/logstash${DISTRIBUTION_SUFFIX}:${ELASTIC_STACK_VERSION}
 # install and enable password-less sudo for logstash user


### PR DESCRIPTION
### Description
Add `ELASTICSEARCH_TREEISH` arg to Dockerfile to dynamically use through the ENV.