### PR TITLE
fix: allow non-snapshot oss-only builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       dockerfile: .ci/Dockerfile
       args:
         - ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
-        - DISTRIBUTION=${DISTRIBUTION:-default}
+        - DISTRIBUTION_SUFFIX=${DISTRIBUTION_SUFFIX:-}
         #- INTEGRATION=false
     command: .ci/run.sh
     env_file: ${DOCKER_ENV:-docker.env}


### PR DESCRIPTION
The docker-compose needs to pass the _resolved_ distro suffix as an arg for the dockerfile, not the pre-resolved distro name


## Release notes

 - Fixes shared CI resolution to validate `SNAPSHOT=false` `DISTRIBUTION=oss` builds using docker containers from the OSS-licensed `logstash-oss` project, instead of using the Elastic-licensed `logstash` project.

## What does this PR do?

Ensures that the container as defined by the `Dockerfile` has the `DISTRIBUTION_SUFFIX` that has already been resolved, instead of the `DISTRIBUTION` variable that _cannot_ be resolved inside the `Dockerfile`'s context

## Why is it important/What is the impact to the user?

Ensures that we can run plugin tests against released, OSS-only containers.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## How to test this PR locally

In any plugin that uses this shared .ci, apply this patch manually and then invoke tests like:
~~~
(export DISTRIBUTION=default ELASTIC_STACK_VERSION=8.x SNAPSHOT=false; .ci/docker-setup.sh && .ci/docker-run.sh) 
~~~

With variabts of:
 - `SNAPSHOT` being `true`, `false`, or unset (effectively `false`);
 - `DISTRIBUTION` being `oss`, `default`, or unset (effectively `default`);
 - `ELASTIC_STACK_VERSION` being `8.x` or `7.x`

Observe the `logstash-oss` container name in the container logs when `DISTRIBUTION` was `oss`:

~~~
Testing against version: 8.11.1 (distribution: oss)
[...]
 => [logstash internal] load metadata for docker.elastic.co/logstash/logstash-oss:8.11.1                                                                                                                                                                                                                      
~~~

Observe the `logstash` container name in the container logs when `DISTRIBUTION` was _either `default` or unset:

~~~
Testing against version: 8.11.1 (distribution: default)
[...]
 => [logstash internal] load metadata for docker.elastic.co/logstash/logstash:8.11.1                                                                                                                                                                                                                      
~~~
