### PR TITLE
adapt to new branching strategy

### DIFF
--- a/travis/matrix.yml
+++ b/travis/matrix.yml
@@ -15,8 +15,8 @@ stages:
 
 env:
   jobs:
-    - ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
-    - ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
+    - ELASTIC_STACK_VERSION=8.n DOCKER_ENV=dockerjdk21.env
+    - ELASTIC_STACK_VERSION=8.n-1 DOCKER_ENV=dockerjdk21.env
     - ELASTIC_STACK_VERSION=7.x
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.n DOCKER_ENV=dockerjdk21.env

--- a/travis/matrix.yml
+++ b/travis/matrix.yml
@@ -15,9 +15,12 @@ stages:
 
 env:
   jobs:
-    - ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env
+    - ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
+    - ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
     - ELASTIC_STACK_VERSION=7.x
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=7.x
 
 jobs:
@@ -26,6 +29,8 @@ jobs:
   <<: *_performance
   env: ELASTIC_STACK_VERSION=7.x
 - <<: *_performance
-  env: ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env
+  env: ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
+- <<: *_performance
+  env: ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
 - <<: *_performance
   env: SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env

--- a/travis/matrix.yml
+++ b/travis/matrix.yml
@@ -23,7 +23,7 @@ env:
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.next DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=7.x
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=7.current
 
 jobs:
 - stage: Performance

--- a/travis/matrix.yml
+++ b/travis/matrix.yml
@@ -19,8 +19,8 @@ env:
     - ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
     - ELASTIC_STACK_VERSION=7.x
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.n DOCKER_ENV=dockerjdk21.env
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.n-1 DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=7.x
 
 jobs:
@@ -29,8 +29,8 @@ jobs:
   <<: *_performance
   env: ELASTIC_STACK_VERSION=7.x
 - <<: *_performance
-  env: ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
+  env: ELASTIC_STACK_VERSION=8.n DOCKER_ENV=dockerjdk21.env
 - <<: *_performance
-  env: ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
+  env: ELASTIC_STACK_VERSION=8.n-1 DOCKER_ENV=dockerjdk21.env
 - <<: *_performance
   env: SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env

--- a/travis/matrix.yml
+++ b/travis/matrix.yml
@@ -15,22 +15,26 @@ stages:
 
 env:
   jobs:
-    - ELASTIC_STACK_VERSION=8.n DOCKER_ENV=dockerjdk21.env
-    - ELASTIC_STACK_VERSION=8.n-1 DOCKER_ENV=dockerjdk21.env
-    - ELASTIC_STACK_VERSION=7.x
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.n DOCKER_ENV=dockerjdk21.env
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.n-1 DOCKER_ENV=dockerjdk21.env
+    - ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
+    - ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
+    - ELASTIC_STACK_VERSION=7.current
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=main DOCKER_ENV=dockerjdk21.env
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.future DOCKER_ENV=dockerjdk21.env
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.next DOCKER_ENV=dockerjdk21.env
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
+    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=7.x
 
 jobs:
 - stage: Performance
   name: Performance Base-Line
   <<: *_performance
-  env: ELASTIC_STACK_VERSION=7.x
+  env: ELASTIC_STACK_VERSION=7.current
 - <<: *_performance
-  env: ELASTIC_STACK_VERSION=8.n DOCKER_ENV=dockerjdk21.env
+  env: ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
 - <<: *_performance
-  env: ELASTIC_STACK_VERSION=8.n-1 DOCKER_ENV=dockerjdk21.env
+  env: ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
 - <<: *_performance
-  env: SNAPSHOT=true ELASTIC_STACK_VERSION=8.x DOCKER_ENV=dockerjdk21.env
+  env: SNAPSHOT=true ELASTIC_STACK_VERSION=8.future DOCKER_ENV=dockerjdk21.env
+- <<: *_performance
+  env: SNAPSHOT=true ELASTIC_STACK_VERSION=main DOCKER_ENV=dockerjdk21.env


### PR DESCRIPTION
Other than the current 7. release, for 8.x there will now be two simultaneous releases we need to test against. 
Let's call them "8.current" and "8.previous".

For snapshots we'll also test against "main", "8.next", and "8.future". The labels are:

- `main`: main branch
-  `8.future`: the future 8.x release, i.e. current version of the 8.x branch
- `8.next`: the short lived period between a minor's FF - when the new branch is cut from 8.x - and GA
- `8.current`: the most recent 8.x release
- `8.previous`: the previous, but still supported, 8.x release

This requires a corresponding PR in elastic/logstash: https://github.com/elastic/logstash/pull/16585