### PR TITLE
gracefully accept that 8.next may not exist

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -20,7 +20,7 @@ if [ -z "${ELASTIC_STACK_VERSION}" ]; then
 fi
 
 echo "Fetching versions from $VERSION_URL"
-VERSIONS=$(curl $VERSION_URL)
+VERSIONS=$(curl -s $VERSION_URL)
 
 if [[ "$SNAPSHOT" = "true" ]]; then
   ELASTIC_STACK_RETRIEVED_VERSION=$(echo $VERSIONS | jq '.snapshots."'"$ELASTIC_STACK_VERSION"'"')
@@ -35,6 +35,9 @@ if [[ "$ELASTIC_STACK_RETRIEVED_VERSION" != "null" ]]; then
   ELASTIC_STACK_RETRIEVED_VERSION="${ELASTIC_STACK_RETRIEVED_VERSION#\"}"
   echo "Translated $ELASTIC_STACK_VERSION to ${ELASTIC_STACK_RETRIEVED_VERSION}"
   export ELASTIC_STACK_VERSION=$ELASTIC_STACK_RETRIEVED_VERSION
+elif [[ "$ELASTIC_STACK_VERSION" == "8.next" ]]; then
+  # we know "8.next" only exists between FF and GA of a minor
+  exit 0
 fi
 
 case "${DISTRIBUTION}" in


### PR DESCRIPTION
8.next will only exist in the brief period between a new minor's FF and GA, so it's fine if the version dictionary returns a null, e.g.:

```json
{
  "releases": {
    "7.current": "7.17.25",
    "8.previous": "8.15.4",
    "8.current": "8.16.0"
  },
  "snapshots": {
    "7.current": "7.17.26-SNAPSHOT",
    "8.previous": "8.15.5-SNAPSHOT",
    "8.current": "8.16.1-SNAPSHOT",
    "8.next": null,
    "8.future": "8.17.0-SNAPSHOT",
    "main": "9.0.0-SNAPSHOT"
  }
}
```