### PR TITLE
Update docker-setup.sh to allow the absence of a 8.future snapshot.

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -13,7 +13,7 @@ pull_docker_snapshot() {
     echo "docker pull successful"
   else
     case $stack_version_alias in
-      "8.previous"|"8.current"|"8.next")
+      "8.previous"|"8.current"|"8.next"|"8.future")
         exit 1
         ;;
       *)


### PR DESCRIPTION
An 8.future may exist in the releases list, but a build may not yet be available and that's OK, so let's allow that to be green.