### PR TITLE
support 9.x ubi-minimal based images with microdnf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,19 @@ FROM docker.elastic.co/logstash/logstash${DISTRIBUTION_SUFFIX}:${ELASTIC_STACK_V
 # install and enable password-less sudo for logstash user
 # allows modifying the system inside the container (using the .ci/setup.sh hook)
 USER root
+# use "apt-get" for 7.x and 8.x images based on ubuntu 20 and "microdnf" for 9.x images based on ubi8-minimal
 RUN if [ $(command -v apt-get) ]; then \
       apt-get update -y && apt-get install -y sudo && \
       gpasswd -a logstash sudo; \
     else \
-      yum install -y sudo && \
+      microdnf install -y sudo && \
       usermod -aG wheel logstash; \
     fi
 RUN if [ $(command -v apt-get) ]; then \
       apt-get update -y --fix-missing && \
       apt-get install -y shared-mime-info; \
     else \
-      yum install -y shared-mime-info; \
+      microdnf install -y shared-mime-info; \
     fi
 RUN echo "logstash ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/logstash && \
     chmod 0440 /etc/sudoers.d/logstash


### PR DESCRIPTION
7.x and 8.x images are based on ubuntu 20 and use the apt package manager while the new ubi-minimal based images for 9.x use the microdnf package manager.
This PR leverages the existing conditional to decide on microdnf vs apt-get given we no longer have centos based images for a long time.