### PR TITLE
Add env vars required by elastic_integraion plugin.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,10 @@ RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logsta
 # NOTE: since 8.0 JDK is bundled as part of the LS distribution under $LS_HOME/jdk
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/jdk/bin"
 ENV LOGSTASH_SOURCE="1"
+ENV LOGSTASH_PATH="/usr/share/logstash"
 ENV ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
+ARG ELASTICSEARCH_TREEISH
+ENV ELASTICSEARCH_TREEISH=$ELASTICSEARCH_TREEISH
 # DISTRIBUTION="default" (by default) or "oss"
 ARG DISTRIBUTION
 ENV DISTRIBUTION=$DISTRIBUTION

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logsta
 # NOTE: since 8.0 JDK is bundled as part of the LS distribution under $LS_HOME/jdk
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin:/usr/share/logstash/jdk/bin"
 ENV LOGSTASH_SOURCE="1"
-ENV LOGSTASH_PATH="/usr/share/logstash"
 ENV ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
 ARG ELASTICSEARCH_TREEISH
 ENV ELASTICSEARCH_TREEISH=$ELASTICSEARCH_TREEISH


### PR DESCRIPTION
### Description

Adds `ELASTICSEARCH_TREEISH` env var which will be used by `elastic_integration` plugin.