### PR TITLE
Track logstash versions in .ci

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -23,8 +23,6 @@ check_docker_snapshot() {
   fi
 }
 
-VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash_releases.json"
-
 if [ -z "${ELASTIC_STACK_VERSION}" ]; then
     echo "Please set the ELASTIC_STACK_VERSION environment variable"
     echo "For example: export ELASTIC_STACK_VERSION=9.x"
@@ -34,26 +32,23 @@ fi
 # The ELASTIC_STACK_VERSION may be an alias, save the original before translating it
 ELASTIC_STACK_VERSION_ALIAS="$ELASTIC_STACK_VERSION"
 
-echo "Fetching versions from $VERSION_URL"
-VERSIONS=$(curl -s $VERSION_URL)
 
+echo "Computing latest stream version"
+VERSION_CONFIG_FILE="logstash-versions.yml"
 if [[ "$SNAPSHOT" = "true" ]]; then
-  ELASTIC_STACK_RETRIEVED_VERSION=$(echo $VERSIONS | jq '.snapshots."'"$ELASTIC_STACK_VERSION"'"')
-  echo $ELASTIC_STACK_RETRIEVED_VERSION
+  ELASTIC_STACK_RETRIEVED_VERSION=$(ruby -r yaml -e "puts YAML.load_file('$VERSION_CONFIG_FILE')['snapshots']['$ELASTIC_STACK_VERSION']")
 else
-  ELASTIC_STACK_RETRIEVED_VERSION=$(echo $VERSIONS | jq '.releases."'"$ELASTIC_STACK_VERSION"'"')
+  ELASTIC_STACK_RETRIEVED_VERSION=$(ruby -r yaml -e "puts YAML.load_file('$VERSION_CONFIG_FILE')['releases']['$ELASTIC_STACK_VERSION']")
 fi
 
-if [[ "$ELASTIC_STACK_RETRIEVED_VERSION" != "null" ]]; then
-  # remove starting and trailing double quotes
-  ELASTIC_STACK_RETRIEVED_VERSION="${ELASTIC_STACK_RETRIEVED_VERSION%\"}"
-  ELASTIC_STACK_RETRIEVED_VERSION="${ELASTIC_STACK_RETRIEVED_VERSION#\"}"
-  echo "Translated $ELASTIC_STACK_VERSION to ${ELASTIC_STACK_RETRIEVED_VERSION}"
+if [[ -n "$ELASTIC_STACK_RETRIEVED_VERSION" ]]; then
+  echo "Translating ELASTIC_STACK_VERSION to ${ELASTIC_STACK_RETRIEVED_VERSION}"
   export ELASTIC_STACK_VERSION=$ELASTIC_STACK_RETRIEVED_VERSION
 elif [[ "$ELASTIC_STACK_VERSION" == "9.next" ]]; then
-  # we know "9.next" only exists between FF and GA of a minor
-  # exit 99 so the build is skipped
   exit 99
+else
+  # CODEREVIEW: should this exit non zero? 
+  echo "Warning: No version found for $ELASTIC_STACK_VERSION, using as-is"
 fi
 
 case "${DISTRIBUTION}" in

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -47,8 +47,8 @@ if [[ -n "$ELASTIC_STACK_RETRIEVED_VERSION" ]]; then
 elif [[ "$ELASTIC_STACK_VERSION" == "9.next" ]]; then
   exit 99
 else
-  # CODEREVIEW: should this exit non zero? 
-  echo "Warning: No version found for $ELASTIC_STACK_VERSION, using as-is"
+  # No version translation found, assuming user provided explicit version
+  echo "No version found for $ELASTIC_STACK_VERSION, using as-is"
 fi
 
 case "${DISTRIBUTION}" in

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -34,7 +34,7 @@ ELASTIC_STACK_VERSION_ALIAS="$ELASTIC_STACK_VERSION"
 
 
 echo "Computing latest stream version"
-VERSION_CONFIG_FILE="logstash-versions.yml"
+VERSION_CONFIG_FILE="$(dirname "$0")/logstash-versions.yml"
 if [[ "$SNAPSHOT" = "true" ]]; then
   ELASTIC_STACK_RETRIEVED_VERSION=$(ruby -r yaml -e "puts YAML.load_file('$VERSION_CONFIG_FILE')['snapshots']['$ELASTIC_STACK_VERSION']")
 else

--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -1,0 +1,16 @@
+# For all active streams track the latest 2 releases
+releases:
+  7.current: "7.17.29"
+  8.previous: "8.18.4" 
+  8.current: "8.19.0"
+  9.previous: "9.0.4"
+  9.current: "9.1.0"
+
+# Track the ongoing SNAPSHOT for the "next" release for each stream
+snapshots:
+  7.current: "7.17.30-SNAPSHOT"
+  8.previous: "8.18.5-SNAPSHOT"
+  8.current: "8.19.1-SNAPSHOT" 
+  9.previous: "9.0.5-SNAPSHOT"
+  9.current: "9.1.1-SNAPSHOT"
+  main: "9.2.0-SNAPSHOT"


### PR DESCRIPTION
Previously logstash versions were tracked in the logstash repo and curled during CI steps. This commit moves the source of truth to the `.ci` repo where the consumer of that information lives. This also changes the format from json to yaml to allow commenting in the file.

We will want to make sure that projects that override this are also updated:

- ~[ ] https://github.com/logstash-plugins/logstash-input-jdbc/blob/878a73eb67b68366fac74fcc65e9cadd6cf44766/ci/unit/docker-setup.sh#L7~ Outdated plugin, does not seem to be running tests. 
- ~[ ] https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/blob/2ed23b51c0b9b1a57e39bf672f6f013eae88d5fc/ci/unit/docker-setup.sh#L7~ Outdated plugin, does not seem to be running tests.
- [x]  https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/f7cf1d636c1fbd5ddcbb92f16ada943132e89a88/.ci/docker-setup.sh#L26: https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1221
- [x] https://github.com/logstash-plugins/logstash-integration-rabbitmq/blob/20be9fd6f1bad91bbb51221dfb92efde9da8e312/.ci/docker-setup.sh#L34: https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/63