### PR TITLE
Update versions

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -4,7 +4,7 @@ releases:
   8.previous: "8.18.4" 
   8.current: "8.19.1"
   9.previous: "9.0.4"
-  9.current: "9.1.0"
+  9.current: "9.1.1"
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:
@@ -12,5 +12,5 @@ snapshots:
   8.previous: "8.18.5-SNAPSHOT"
   8.current: "8.19.2-SNAPSHOT" 
   9.previous: "9.0.5-SNAPSHOT"
-  9.current: "9.1.1-SNAPSHOT"
+  9.current: "9.1.2-SNAPSHOT"
   main: "9.2.0-SNAPSHOT"

--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -2,7 +2,7 @@
 releases:
   7.current: "7.17.29"
   8.previous: "8.18.4" 
-  8.current: "8.19.0"
+  8.current: "8.19.1"
   9.previous: "9.0.4"
   9.current: "9.1.0"
 
@@ -10,7 +10,7 @@ releases:
 snapshots:
   7.current: "7.17.30-SNAPSHOT"
   8.previous: "8.18.5-SNAPSHOT"
-  8.current: "8.19.1-SNAPSHOT" 
+  8.current: "8.19.2-SNAPSHOT" 
   9.previous: "9.0.5-SNAPSHOT"
   9.current: "9.1.1-SNAPSHOT"
   main: "9.2.0-SNAPSHOT"


### PR DESCRIPTION
Update logstash version for 8.19.1 and 9.1.1 releases. 

Blocked on:

 - https://github.com/elastic/logstash/pull/17921
 - https://github.com/elastic/logstash/pull/17919