### PR TITLE
Set travis no-output timeout

### DIFF
--- a/travis/exec.yml
+++ b/travis/exec.yml
@@ -26,5 +26,5 @@ script:
     if [ "$SKIP_SCRIPT" = "true" ]; then
       exit 0
     else
-      .ci/docker-run.sh
+      travis_wait 30 .ci/docker-run.sh
     fi


### PR DESCRIPTION
jms-input [CI](https://app.travis-ci.com/github/logstash-plugins/logstash-input-jms/jobs/635187288) fail due to the time taking to download jar is longer than 10 minutes

This commit set the no-output timeout of docker run to 30 minutes