### PR TITLE
Update logstash for 9/16/25 release

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -1,16 +1,16 @@
 # For all active streams track the latest 2 releases
 releases:
   7.current: "7.17.29"
-  8.previous: "8.18.5" 
+  8.previous: "8.18.7"
   8.current: "8.19.4"
-  9.previous: "9.0.5"
+  9.previous: "9.0.7"
   9.current: "9.1.4"
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:
   7.current: "7.17.30-SNAPSHOT"
-  8.previous: "8.18.6-SNAPSHOT"
+  8.previous: "8.18.8-SNAPSHOT"
   8.current: "8.19.5-SNAPSHOT"
-  9.previous: "9.0.6-SNAPSHOT"
+  9.previous: "9.0.8-SNAPSHOT"
   9.current: "9.1.5-SNAPSHOT"
   main: "9.2.0-SNAPSHOT"


### PR DESCRIPTION
This commit updates the release versions for logstash based on the 8.18.7 and 9.0.7 releases published today.
