### PR TITLE
Update logstash for 9/18/25 release

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -2,15 +2,15 @@
 releases:
   7.current: "7.17.29"
   8.previous: "8.18.5" 
-  8.current: "8.19.3"
+  8.current: "8.19.4"
   9.previous: "9.0.5"
-  9.current: "9.1.3"
+  9.current: "9.1.4"
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:
   7.current: "7.17.30-SNAPSHOT"
   8.previous: "8.18.6-SNAPSHOT"
-  8.current: "8.19.4-SNAPSHOT"
+  8.current: "8.19.5-SNAPSHOT"
   9.previous: "9.0.6-SNAPSHOT"
-  9.current: "9.1.4-SNAPSHOT"
+  9.current: "9.1.5-SNAPSHOT"
   main: "9.2.0-SNAPSHOT"


### PR DESCRIPTION
This commit updates the release versions for logstash based on the 8.19.4 and 9.1.4 releases published today.
