### PR TITLE
Add mac (bsdtar) support for fetching and installing scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,29 @@ and then rebuild the image:
 ```
 .ci/docker-setup.sh && .ci/docker-run.sh
 ```
+
+## add-scripts-to-current-plugin.sh
+
+Bootstrap this repo's `.ci` assets into a Logstash plugin repository from your local checkout.
+
+### Prerequisites
+
+- `yq` must be installed (used to read `travis/exec.yml`). For macOS with Homebrew:
+  ```
+  brew install yq
+  ```
+- `curl` and `tar` available in your shell.
+
+### Usage
+
+1. Change directory to the root of your plugin (must contain a `logstash-*.gemspec`).
+2. Run the script from this repo:
+   ```
+   /path/to/logstash-plugins/.ci/add-scripts-to-current-plugin.sh
+   ```
+
+### What it does
+
+- 
+
+If `yq` is not installed or `travis/exec.yml` cannot be found, the script will exit with an error message.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ and then rebuild the image:
 .ci/docker-setup.sh && .ci/docker-run.sh
 ```
 
-## add-scripts-to-current-plugin.sh
+## Running docker containers locally for plugins
 
-Bootstrap this repo's `.ci` assets into a Logstash plugin repository from your local checkout.
+Run `path/to/this/repo/add-scripts-to-current-plugin.sh` from within your plugin root to
+unpack the published scripts into your plugin in the same way CI would.
+
+Then, you can run `docker-setup.sh` and `docker-run.sh` to actually run the tests. You likely
+will want to set environment variables from the plugin's `travis.yml` before running `docker-run.sh`.
 
 ### Prerequisites
 
@@ -53,17 +57,3 @@ Bootstrap this repo's `.ci` assets into a Logstash plugin repository from your l
   brew install yq
   ```
 - `curl` and `tar` available in your shell.
-
-### Usage
-
-1. Change directory to the root of your plugin (must contain a `logstash-*.gemspec`).
-2. Run the script from this repo:
-   ```
-   /path/to/logstash-plugins/.ci/add-scripts-to-current-plugin.sh
-   ```
-
-### What it does
-
-- 
-
-If `yq` is not installed or `travis/exec.yml` cannot be found, the script will exit with an error message.

--- a/add-scripts-to-current-plugin.sh
+++ b/add-scripts-to-current-plugin.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+# Ensure we are in the root of a Logstash plugin
+if ls logstash-*.gemspec >/dev/null 2>&1; then
+  echo "Detected Logstash plugin gemspec. Proceeding to add .ci scripts..."
+else
+  echo "Error: This does not appear to be the root of a Logstash plugin (missing logstash-*.gemspec)." >&2
+  exit 1
+fi
+
+# Run .before_install[0] from travis/exec.yml using yq
+if ! command -v yq >/dev/null 2>&1; then
+  echo "Error: 'yq' is required but not installed. Please install yq (e.g., 'brew install yq') and retry." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXEC_YAML="$SCRIPT_DIR/travis/exec.yml"
+
+if [ ! -f "$EXEC_YAML" ]; then
+  echo "Error: Could not find $EXEC_YAML" >&2
+  exit 1
+fi
+
+CMD=$(yq -r '.before_install[0]' "$EXEC_YAML")
+if [ -z "$CMD" ] || [ "$CMD" = "null" ]; then
+  echo "Error: No before_install[0] command found in $EXEC_YAML" >&2
+  exit 1
+fi
+
+echo "Executing: $CMD"
+bash -lc "$CMD"
+
+echo "Successfully added .ci scripts to the plugin."
+

--- a/travis/exec.yml
+++ b/travis/exec.yml
@@ -1,5 +1,7 @@
 before_install:
-  - mkdir -p .ci && curl -sL https://github.com/logstash-plugins/.ci/archive/1.x.tar.gz | tar zxvf - --skip-old-files --strip-components=1 -C .ci --wildcards "*Dockerfile*" "*docker*" "*.sh" "*logstash-versions*"
+  # Bootstrap CI assets and untar using the right flags for GNU vs. BSD tar. BSD tar doesn't need the wildcards flag because
+  # wildcards are supported by default.
+  - mkdir -p .ci && curl -sL https://github.com/logstash-plugins/.ci/archive/1.x.tar.gz | sh -c 'if tar --version 2>/dev/null | grep -q "GNU tar"; then TAR_KEEP="--skip-old-files"; TAR_WILDCARDS="--wildcards"; else TAR_KEEP="-k"; TAR_WILDCARDS=""; fi; tar -xzvf - $TAR_KEEP --strip-components=1 -C .ci $TAR_WILDCARDS "*Dockerfile*" "*docker*" "*.sh" "*logstash-versions*"'
 install:
   - |
     .ci/docker-setup.sh;


### PR DESCRIPTION
This makes the curl and tar / untar step for unpacking scripts mac (bsdtar) compatible. It also adds a nice helper script for running it easily locally.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~- [] I have made corresponding change to the default configuration files (and/or docker env variables)~
~- [ ] I have added tests that prove my fix is effective or that my feature works~

## Author's Checklist

- [ ] Try running it in a plugin directory
- [ ] Try running it with / without yq installed