### PR TITLE
Update 8.current snapshot to 8.19.7

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -10,7 +10,7 @@ releases:
 snapshots:
   7.current: "7.17.30-SNAPSHOT"
   8.previous: "8.18.9-SNAPSHOT"
-  8.current: "8.19.6-SNAPSHOT"
+  8.current: "8.19.7-SNAPSHOT"
   9.previous: "9.1.7-SNAPSHOT"
   9.current: "9.2.1-SNAPSHOT"
   main: "9.3.0-SNAPSHOT"


### PR DESCRIPTION
Unified release is available. Update to 8.19.7 for 8.current.

