### PR TITLE
Propagate integration env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       args:
         - ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
         - DISTRIBUTION_SUFFIX=${DISTRIBUTION_SUFFIX:-}
-        #- INTEGRATION=false
+        - INTEGRATION={$INTEGRATION:false}
     command: .ci/run.sh
     env_file: ${DOCKER_ENV:-docker.env}
     environment:


### PR DESCRIPTION
I have found (with my ongoing [PR](https://github.com/logstash-plugins/logstash-codec-avro/pull/47)) that when running integration tests by setting `INTEGRATION=true` var, this var is not applied in docker env. It looks like we need to add it to the docker-composer.yml.