### PR TITLE
Wait for unified release job before bumping snapshots

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -10,7 +10,7 @@ releases:
 snapshots:
   7.current: "7.17.30-SNAPSHOT"
   8.previous: "8.18.9-SNAPSHOT"
-  8.current: "8.19.9-SNAPSHOT"
-  9.previous: "9.1.9-SNAPSHOT"
-  9.current: "9.2.3-SNAPSHOT"
+  8.current: "8.19.8-SNAPSHOT"
+  9.previous: "9.1.8-SNAPSHOT"
+  9.current: "9.2.2-SNAPSHOT"
   main: "9.3.0-SNAPSHOT"


### PR DESCRIPTION
Downgrade expected snapshot versions until builds are available.
