### PR TITLE
Remove testing for deprecated 7.x release track

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -1,6 +1,5 @@
 # For all active streams track the latest 2 releases
 releases:
-  7.current: "7.17.29"
   8.previous: "8.18.8"
   8.current: "8.19.10"
   9.previous: "9.1.10"
@@ -8,7 +7,6 @@ releases:
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:
-  7.current: "7.17.30-SNAPSHOT"
   8.previous: "8.18.9-SNAPSHOT"
   8.current: "8.19.11-SNAPSHOT"
   9.previous: "9.1.11-SNAPSHOT"


### PR DESCRIPTION
This commit removes entries for testing the 7 major version.

NOTE: This should be merged **after** all references to 7.current are removed from travis matrixes etc. 