### PR TITLE
Remove testing for the major version 7 for default travis matrix

### DIFF
--- a/travis/matrix.yml
+++ b/travis/matrix.yml
@@ -19,21 +19,17 @@ env:
     - ELASTIC_STACK_VERSION=9.previous DOCKER_ENV=dockerjdk21.env
     - ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
     - ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
-    - ELASTIC_STACK_VERSION=7.current
     - SNAPSHOT=true ELASTIC_STACK_VERSION=main DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=9.next DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=9.current DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=9.previous DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=7.current
 
 jobs:
 - stage: Performance
   name: Performance Base-Line
   <<: *_performance
-  env: ELASTIC_STACK_VERSION=7.current
-- <<: *_performance
   env: ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
 - <<: *_performance
   env: ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env


### PR DESCRIPTION
This commit removes cells for testing against the major version 7 as it has been deprecated.