### PR TITLE
Update logstash release versions

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -1,14 +1,15 @@
 # For all active streams track the latest 2 releases
 releases:
   8.previous: "8.18.8"
-  8.current: "8.19.10"
-  9.previous: "9.1.10"
-  9.current: "9.2.4"
+  8.current: "8.19.11"
+  9.previous: "9.2.5"
+  9.current: "9.3.0"
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:
   8.previous: "8.18.9-SNAPSHOT"
-  8.current: "8.19.11-SNAPSHOT"
-  9.previous: "9.1.11-SNAPSHOT"
-  9.current: "9.2.5-SNAPSHOT"
-  main: "9.3.0-SNAPSHOT"
+  8.current: "8.19.12-SNAPSHOT"
+  9.previous: "9.2.6-SNAPSHOT"
+  #TODO: update 9.current to 9.3.1-SNAPSHOT once unified release is squared away
+  9.current: "9.2.6-SNAPSHOT"
+  main: "9.4.0-SNAPSHOT"


### PR DESCRIPTION
This commit updates for the 8.19.11, 9.2.5 and 9.3.0 with the exception of the 9.3.1-SNAPSHOT as it is delayed. That will come in a follow on PR.

Note: this is taking everyrtghing that is ready from https://github.com/logstash-plugins/.ci/pull/109/changes so we can be testing against latest bnuilds without being blocked on unified release for 9.3.1-snapshot. 