### PR TITLE
Clean up 8.previous as we no longer release.

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -13,7 +13,7 @@ check_docker_snapshot() {
     echo "docker image exists. proceeding..."
   else
     case $stack_version_alias in
-      "8.previous"|"8.current"|"9.previous"|"9.current"|"9.next")
+      "8.current"|"9.previous"|"9.current"|"9.next")
         exit 99
         ;;
       *)

--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -1,13 +1,11 @@
 # For all active streams track the latest 2 releases
 releases:
-  8.previous: "8.18.8"
   8.current: "8.19.11"
   9.previous: "9.2.5"
   9.current: "9.3.0"
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:
-  8.previous: "8.18.9-SNAPSHOT"
   8.current: "8.19.12-SNAPSHOT"
   9.previous: "9.2.6-SNAPSHOT"
   #TODO: update 9.current to 9.3.1-SNAPSHOT once unified release is squared away

--- a/travis/matrix.yml
+++ b/travis/matrix.yml
@@ -18,21 +18,17 @@ env:
     - ELASTIC_STACK_VERSION=9.current DOCKER_ENV=dockerjdk21.env
     - ELASTIC_STACK_VERSION=9.previous DOCKER_ENV=dockerjdk21.env
     - ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
-    - ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=main DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=9.next DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=9.current DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=9.previous DOCKER_ENV=dockerjdk21.env
     - SNAPSHOT=true ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
-    - SNAPSHOT=true ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
 
 jobs:
 - stage: Performance
   name: Performance Base-Line
   <<: *_performance
   env: ELASTIC_STACK_VERSION=8.current DOCKER_ENV=dockerjdk21.env
-- <<: *_performance
-  env: ELASTIC_STACK_VERSION=8.previous DOCKER_ENV=dockerjdk21.env
 - <<: *_performance
   env: ELASTIC_STACK_VERSION=9.current DOCKER_ENV=dockerjdk21.env
 - <<: *_performance


### PR DESCRIPTION
Removes `8.previous` from the central CI.