### PR TITLE
Update snapshot versions for logstash

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -6,7 +6,7 @@ releases:
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:
-  8.current: "8.19.12-SNAPSHOT"
-  9.previous: "9.2.6-SNAPSHOT"
-  9.current: "9.3.1-SNAPSHOT"
+  8.current: "8.19.13-SNAPSHOT"
+  9.previous: "9.2.7-SNAPSHOT"
+  9.current: "9.3.2-SNAPSHOT"
   main: "9.4.0-SNAPSHOT"


### PR DESCRIPTION
This commit follows up on https://github.com/logstash-plugins/.ci/pull/115 where the release versions were updated (without snapshot) as they were required for green CI while we waited for snapshot versions to be available. Snapshot versions are now available.
