### PR TITLE
Revert premature snapshot bumps

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -6,7 +6,7 @@ releases:
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:
-  8.current: "8.19.14-SNAPSHOT"
-  9.previous: "9.2.8-SNAPSHOT"
-  9.current: "9.3.3-SNAPSHOT"
+  8.current: "8.19.13-SNAPSHOT"
+  9.previous: "9.2.7-SNAPSHOT"
+  9.current: "9.3.2-SNAPSHOT"
   main: "9.4.0-SNAPSHOT"


### PR DESCRIPTION
The snapshot DRA has not been composed yet. Revert bumps until that has happend to avoid failures in logstash CI.

Partially reverts:
- https://github.com/logstash-plugins/.ci/commit/7926db339c31cdb5e9a33b75221d7d4805b601be
- https://github.com/logstash-plugins/.ci/pull/118/changes
- https://github.com/logstash-plugins/.ci/pull/117/changes