### PR TITLE
[DO NOT MERGE] Revert "Revert premature snapshot bumps"

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -6,7 +6,7 @@ releases:
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:
-  8.current: "8.19.13-SNAPSHOT"
-  9.previous: "9.2.7-SNAPSHOT"
-  9.current: "9.3.2-SNAPSHOT"
+  8.current: "8.19.14-SNAPSHOT"
+  9.previous: "9.2.8-SNAPSHOT"
+  9.current: "9.3.3-SNAPSHOT"
   main: "9.4.0-SNAPSHOT"


### PR DESCRIPTION
Reverts logstash-plugins/.ci#119

This should not be merged until CI is green (indicating unified release has been composed for all new version). 