### PR TITLE
9.4 FF follow-up

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -3,10 +3,12 @@ releases:
   8.current: "8.19.14"
   9.previous: "9.2.8"
   9.current: "9.3.3"
+  9.next: "9.4.0"
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:
   8.current: "8.19.15-SNAPSHOT"
   9.previous: "9.2.8-SNAPSHOT"
   9.current: "9.3.4-SNAPSHOT"
-  main: "9.4.0-SNAPSHOT"
+  9.next: "9.4.0-SNAPSHOT"
+  main: "9.5.0-SNAPSHOT"

--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -3,7 +3,6 @@ releases:
   8.current: "8.19.14"
   9.previous: "9.2.8"
   9.current: "9.3.3"
-  9.next: "9.4.0"
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:


### PR DESCRIPTION
Adds `9.next` entries for 9.4 branch, moves main snapshots to 9.5.0
