### PR TITLE
Bump released (and ready) logstash versions

### DIFF
--- a/logstash-versions.yml
+++ b/logstash-versions.yml
@@ -1,8 +1,8 @@
 # For all active streams track the latest 2 releases
 releases:
-  8.current: "8.19.14"
+  8.current: "8.19.15"
   9.previous: "9.2.8"
-  9.current: "9.3.3"
+  9.current: "9.3.4"
 
 # Track the ongoing SNAPSHOT for the "next" release for each stream
 snapshots:


### PR DESCRIPTION
Start testing released versions as they are immediately available, snapshot versions will be bumped when they are available.
