### PR TITLE
use "Stack" instead of "ES" to refer to the Elastic Stack, 

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   integration-tests:
-    name: Integration Tests / ES ${{ matrix.elastic-stack-version }} ${{ matrix.snapshot && '(Snapshot)' || '' }}
+    name: Integration Tests / Stack ${{ matrix.elastic-stack-version }} ${{ matrix.snapshot && '(Snapshot)' || '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   performance:
-    name: Performance Tests / ES ${{ matrix.elastic-stack-version }} ${{ matrix.snapshot && '(Snapshot)' || '' }}
+    name: Performance Tests / Stack ${{ matrix.elastic-stack-version }} ${{ matrix.snapshot && '(Snapshot)' || '' }}
     # Only run performance tests if HAS_PERFORMANCE_TESTS is set to 1
     if: vars.HAS_PERFORMANCE_TESTS == '1'
     runs-on: ubuntu-latest

--- a/.github/workflows/secure-integration-tests.yml
+++ b/.github/workflows/secure-integration-tests.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   secure-integration-tests:
-    name: Secure Integration Tests / ES ${{ matrix.elastic-stack-version }} ${{ matrix.snapshot && '(Snapshot)' || '' }}${{ matrix.es-ssl-key-invalid == 'true' && ' (Invalid SSL)' || '' }}${{ matrix.es-ssl-supported-protocols != '' && format(' ({0})', matrix.es-ssl-supported-protocols) || '' }}
+    name: Secure Integration Tests / Stack ${{ matrix.elastic-stack-version }} ${{ matrix.snapshot && '(Snapshot)' || '' }}${{ matrix.es-ssl-key-invalid == 'true' && ' (Invalid SSL)' || '' }}${{ matrix.es-ssl-supported-protocols != '' && format(' ({0})', matrix.es-ssl-supported-protocols) || '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   unit-tests:
-    name: Unit Tests / ES ${{ matrix.elastic-stack-version }}${{ matrix.snapshot && ' (Snapshot)' || '' }}
+    name: Unit Tests / Stack ${{ matrix.elastic-stack-version }}${{ matrix.snapshot && ' (Snapshot)' || '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
...since ES means "Elasticsearch"

When looking at the [inagural run](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1262/checks) of the GHA workflows, the "ES" in the job titles was confusing to me since my brain parsed it as "Elasticsearch".

This PR avoids that trip-up and keeps it brief by calling it "Stack"