### PR TITLE
Add mechanism for triggering scheduled builds based on branch

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,10 @@ on:
         description: 'Timeout for the test step in minutes'
         type: number
         default: 60
+      ref:
+        description: 'Git ref to check out. Defaults to the caller workflow''s ref; set explicitly when a scheduled matrix job needs to test a non-default branch.'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -31,6 +35,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup test environment
         id: setup

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,6 +2,11 @@ name: Plugin Performance Tests
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to check out. Defaults to the caller workflow''s ref; set explicitly when a scheduled matrix job needs to test a non-default branch.'
+        type: string
+        default: ''
 
 ## Concurrency only allowed in the main branch.
 ## So old builds running for old commits within the same Pull Request are cancelled
@@ -36,6 +41,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup test environment
         id: setup

--- a/.github/workflows/secure-integration-tests.yml
+++ b/.github/workflows/secure-integration-tests.yml
@@ -7,6 +7,10 @@ on:
         description: 'Timeout for the test step in minutes'
         type: number
         default: 60
+      ref:
+        description: 'Git ref to check out. Defaults to the caller workflow''s ref; set explicitly when a scheduled matrix job needs to test a non-default branch.'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -64,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup test environment
         id: setup

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,10 @@ on:
         description: 'Timeout for the test step in minutes'
         type: number
         default: 60
+      ref:
+        description: 'Git ref to check out. Defaults to the caller workflow''s ref; set explicitly when a scheduled matrix job needs to test a non-default branch.'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -36,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup test environment
         id: setup


### PR DESCRIPTION
The schedule only applies to the default branch where the github action defining it is. For plugins which need to run a schedule on multiple branches, we need to be able to trigger a matrix of jobs. This commit updates the shared workflows to accept a ref for which to check out/run when scheduled jobs are triggered.
