### PR TITLE
Add mechanism for consumers to override stack version

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,6 +11,14 @@ on:
         description: 'Git ref to check out. Defaults to the caller workflow''s ref; set explicitly when a scheduled matrix job needs to test a non-default branch.'
         type: string
         default: ''
+      elastic-stack-versions:
+        description: 'JSON array of ELASTIC_STACK_VERSION values to test against. Empty string = use the built-in default matrix (which also adds snapshot-only 9.next and main entries via includes). Setting this drops the include block so you get a strict cartesian product of versions × [snapshot:false, snapshot:true].'
+        type: string
+        default: ''
+      distribution:
+        description: 'Stack distribution (default | oss). Passed through to the setup action as the DISTRIBUTION env var.'
+        type: string
+        default: 'default'
 
 permissions:
   contents: read
@@ -22,15 +30,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elastic-stack-version:
-          - '8.current'
-          - '9.current'
+        elastic-stack-version: ${{ fromJSON(inputs.elastic-stack-versions != '' && inputs.elastic-stack-versions || '["8.current","9.current"]') }}
         snapshot: [false, true]
-        include:
-          - elastic-stack-version: '9.next'
-            snapshot: true
-          - elastic-stack-version: 'main'
-            snapshot: true
+        include: ${{ fromJSON(inputs.elastic-stack-versions != '' && '[]' || '[{"elastic-stack-version":"9.next","snapshot":true},{"elastic-stack-version":"main","snapshot":true}]') }}
 
     steps:
       - name: Checkout code
@@ -45,6 +47,7 @@ jobs:
           elastic-stack-version: ${{ matrix.elastic-stack-version }}
           snapshot: ${{ matrix.snapshot }}
           integration: true
+          distribution: ${{ inputs.distribution }}
 
       - name: Run integration tests
         if: steps.setup.outputs.skip != 'true'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -7,6 +7,14 @@ on:
         description: 'Git ref to check out. Defaults to the caller workflow''s ref; set explicitly when a scheduled matrix job needs to test a non-default branch.'
         type: string
         default: ''
+      elastic-stack-versions:
+        description: 'JSON array of ELASTIC_STACK_VERSION values to test against. Empty string = use the built-in default matrix.'
+        type: string
+        default: ''
+      distribution:
+        description: 'Stack distribution (default | oss). Passed through to the setup action as the DISTRIBUTION env var.'
+        type: string
+        default: 'default'
 
 ## Concurrency only allowed in the main branch.
 ## So old builds running for old commits within the same Pull Request are cancelled
@@ -26,11 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elastic-stack-version:
-          - '8.current'
-          - '9.previous'
-          - '9.current'
-          - 'main'
+        elastic-stack-version: ${{ fromJSON(inputs.elastic-stack-versions != '' && inputs.elastic-stack-versions || '["8.current","9.previous","9.current","main"]') }}
         snapshot: [false, true]
         docker-env: ['dockerjdk21.env']
         exclude:
@@ -51,6 +55,7 @@ jobs:
           elastic-stack-version: ${{ matrix.elastic-stack-version }}
           snapshot: ${{ matrix.snapshot }}
           docker-env: ${{ matrix.docker-env }}
+          distribution: ${{ inputs.distribution }}
 
       - name: Run performance tests
         if: steps.setup.outputs.skip != 'true'

--- a/.github/workflows/secure-integration-tests.yml
+++ b/.github/workflows/secure-integration-tests.yml
@@ -11,6 +11,14 @@ on:
         description: 'Git ref to check out. Defaults to the caller workflow''s ref; set explicitly when a scheduled matrix job needs to test a non-default branch.'
         type: string
         default: ''
+      elastic-stack-versions:
+        description: 'JSON array of ELASTIC_STACK_VERSION values to test against. Empty string = use the built-in default matrix (SSL/TLS variants and snapshot fan-out via includes). Setting this drops all includes and gives you a strict cartesian product of versions × [snapshot:false, snapshot:true] with no SSL/TLS variants.'
+        type: string
+        default: ''
+      distribution:
+        description: 'Stack distribution (default | oss). Passed through to the setup action as the DISTRIBUTION env var.'
+        type: string
+        default: 'default'
 
 permissions:
   contents: read
@@ -22,48 +30,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elastic-stack-version:
-          - '8.current'
-          - '9.current'
-        snapshot: [false]
+        elastic-stack-version: ${{ fromJSON(inputs.elastic-stack-versions != '' && inputs.elastic-stack-versions || '["8.current","9.current"]') }}
+        snapshot: ${{ fromJSON(inputs.elastic-stack-versions != '' && '[false, true]' || '[false]') }}
         es-ssl-key-invalid: ['false']
         es-ssl-supported-protocols: ['']
-        include:
-          # SSL key invalid variants
-          - elastic-stack-version: '8.current'
-            snapshot: false
-            es-ssl-key-invalid: 'true'
-            es-ssl-supported-protocols: ''
-          - elastic-stack-version: '9.current'
-            snapshot: false
-            es-ssl-key-invalid: 'true'
-            es-ssl-supported-protocols: ''
-          # TLSv1.3 variants
-          - elastic-stack-version: '8.current'
-            snapshot: false
-            es-ssl-key-invalid: 'false'
-            es-ssl-supported-protocols: 'TLSv1.3'
-          - elastic-stack-version: '9.current'
-            snapshot: false
-            es-ssl-key-invalid: 'false'
-            es-ssl-supported-protocols: 'TLSv1.3'
-          # Snapshot variants
-          - elastic-stack-version: '8.current'
-            snapshot: true
-            es-ssl-key-invalid: 'false'
-            es-ssl-supported-protocols: ''
-          - elastic-stack-version: '9.current'
-            snapshot: true
-            es-ssl-key-invalid: 'false'
-            es-ssl-supported-protocols: ''
-          - elastic-stack-version: '9.next'
-            snapshot: true
-            es-ssl-key-invalid: 'false'
-            es-ssl-supported-protocols: ''
-          - elastic-stack-version: 'main'
-            snapshot: true
-            es-ssl-key-invalid: 'false'
-            es-ssl-supported-protocols: ''
+        include: ${{ fromJSON(inputs.elastic-stack-versions != '' && '[]' || '[{"elastic-stack-version":"8.current","snapshot":false,"es-ssl-key-invalid":"true","es-ssl-supported-protocols":""},{"elastic-stack-version":"9.current","snapshot":false,"es-ssl-key-invalid":"true","es-ssl-supported-protocols":""},{"elastic-stack-version":"8.current","snapshot":false,"es-ssl-key-invalid":"false","es-ssl-supported-protocols":"TLSv1.3"},{"elastic-stack-version":"9.current","snapshot":false,"es-ssl-key-invalid":"false","es-ssl-supported-protocols":"TLSv1.3"},{"elastic-stack-version":"8.current","snapshot":true,"es-ssl-key-invalid":"false","es-ssl-supported-protocols":""},{"elastic-stack-version":"9.current","snapshot":true,"es-ssl-key-invalid":"false","es-ssl-supported-protocols":""},{"elastic-stack-version":"9.next","snapshot":true,"es-ssl-key-invalid":"false","es-ssl-supported-protocols":""},{"elastic-stack-version":"main","snapshot":true,"es-ssl-key-invalid":"false","es-ssl-supported-protocols":""}]') }}
 
     steps:
       - name: Checkout code
@@ -81,6 +52,7 @@ jobs:
           secure-integration: true
           es-ssl-key-invalid: ${{ matrix.es-ssl-key-invalid }}
           es-ssl-supported-protocols: ${{ matrix.es-ssl-supported-protocols }}
+          distribution: ${{ inputs.distribution }}
 
       - name: Run secure integration tests
         if: steps.setup.outputs.skip != 'true'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,14 @@ on:
         description: 'Git ref to check out. Defaults to the caller workflow''s ref; set explicitly when a scheduled matrix job needs to test a non-default branch.'
         type: string
         default: ''
+      elastic-stack-versions:
+        description: 'JSON array of ELASTIC_STACK_VERSION values to test against. Empty string = use the built-in default matrix.'
+        type: string
+        default: ''
+      distribution:
+        description: 'Stack distribution (default | oss). Passed through to the setup action as the DISTRIBUTION env var.'
+        type: string
+        default: 'default'
 
 permissions:
   contents: read
@@ -22,12 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elastic-stack-version:
-          - '8.current'
-          - '9.previous'
-          - '9.current'
-          - '9.next'
-          - 'main'
+        elastic-stack-version: ${{ fromJSON(inputs.elastic-stack-versions != '' && inputs.elastic-stack-versions || '["8.current","9.previous","9.current","9.next","main"]') }}
         snapshot: [false, true]
         docker-env: ['dockerjdk21.env']
         exclude:
@@ -50,6 +53,7 @@ jobs:
           elastic-stack-version: ${{ matrix.elastic-stack-version }}
           snapshot: ${{ matrix.snapshot }}
           docker-env: ${{ matrix.docker-env }}
+          distribution: ${{ inputs.distribution }}
 
       - name: Run tests
         if: steps.setup.outputs.skip != 'true'

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'SSL/TLS protocols to test'
     required: false
     default: ''
+  distribution:
+    description: 'Stack distribution (default | oss). Maps to the DISTRIBUTION env var read by docker-setup.sh.'
+    required: false
+    default: 'default'
 
 outputs:
   skip:
@@ -48,6 +52,7 @@ runs:
         SECURE_INTEGRATION: ${{ inputs.secure-integration }}
         ES_SSL_KEY_INVALID: ${{ inputs.es-ssl-key-invalid }}
         ES_SSL_SUPPORTED_PROTOCOLS: ${{ inputs.es-ssl-supported-protocols }}
+        DISTRIBUTION: ${{ inputs.distribution }}
       run: |
         echo "LOG_LEVEL=info" >> $GITHUB_ENV
         echo "ELASTIC_STACK_VERSION=${ELASTIC_STACK_VERSION}" >> $GITHUB_ENV
@@ -74,6 +79,10 @@ runs:
 
         if [ -n "${ES_SSL_SUPPORTED_PROTOCOLS}" ]; then
           echo "ES_SSL_SUPPORTED_PROTOCOLS=${ES_SSL_SUPPORTED_PROTOCOLS}" >> $GITHUB_ENV
+        fi
+
+        if [ -n "${DISTRIBUTION}" ]; then
+          echo "DISTRIBUTION=${DISTRIBUTION}" >> $GITHUB_ENV
         fi
 
     - name: Setup Docker Buildx


### PR DESCRIPTION
For some plugins (rare) like enterprise_search we need to override the matrix. This commit adds a mechanism for doing so. This will also provide a "distribution" for use in the geiop plugin. This was developed by doing a scan of logstash-plugins looking for cases where the consumer needs to (in existing travis) override default matrices.
