### PR TITLE
Seed plugin bundle with Logstash image Gemfile.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN gem install bundler -v '< 2'
 WORKDIR /usr/share/plugins/plugin
 COPY --chown=logstash:logstash .ci/* /usr/share/plugins/plugin/.ci/
 RUN .ci/setup.sh
+RUN cp /usr/share/logstash/Gemfile.lock ./Gemfile.lock
 RUN bundle install --with test ci
 COPY --chown=logstash:logstash . /usr/share/plugins/plugin/
 RUN bundle exec rake vendor


### PR DESCRIPTION
Copies the Logstash image's `Gemfile.lock` into the plugin workdir before `bundle install`, so transitive dependency versions match those shipped with the target Logstash image.

When a plugin's gemspec declares a dependency version that conflicts with the seeded lockfile, Bundler upgrades only that gem (and its dependents) while keeping everything else at the locked versions.

## Problem

The current CI Dockerfile runs `bundle install` in the plugin workdir without a `Gemfile.lock`. Bundler re-resolves **all** transitive dependencies from scratch on every CI run. This means plugin CI does not test against the same dependency versions that ship with the target Logstash version.