### PR TITLE
Add mechanism to conditionally send slack messages for plugins

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,6 +19,10 @@ on:
         description: 'Stack distribution (default | oss). Passed through to the setup action as the DISTRIBUTION env var.'
         type: string
         default: 'default'
+      notify-slack:
+        description: 'Send a Slack notification on failure.'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -55,7 +59,7 @@ jobs:
         run: bash .ci/docker-run.sh
 
       - name: Notify Slack on failure
-        if: ${{ failure() && github.event_name != 'pull_request' }}
+        if: ${{ failure() && github.event_name != 'pull_request' && inputs.notify-slack }}
         uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -15,6 +15,10 @@ on:
         description: 'Stack distribution (default | oss). Passed through to the setup action as the DISTRIBUTION env var.'
         type: string
         default: 'default'
+      notify-slack:
+        description: 'Send a Slack notification on failure.'
+        type: boolean
+        default: true
 
 ## Concurrency only allowed in the main branch.
 ## So old builds running for old commits within the same Pull Request are cancelled
@@ -68,7 +72,7 @@ jobs:
           DOCKER_ENV: ${{ matrix.docker-env }}
 
       - name: Notify Slack on failure
-        if: ${{ failure() && github.event_name != 'pull_request' }}
+        if: ${{ failure() && github.event_name != 'pull_request' && inputs.notify-slack }}
         uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/secure-integration-tests.yml
+++ b/.github/workflows/secure-integration-tests.yml
@@ -19,6 +19,10 @@ on:
         description: 'Stack distribution (default | oss). Passed through to the setup action as the DISTRIBUTION env var.'
         type: string
         default: 'default'
+      notify-slack:
+        description: 'Send a Slack notification on failure.'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -60,7 +64,7 @@ jobs:
         run: bash .ci/docker-run.sh
 
       - name: Notify Slack on failure
-        if: ${{ failure() && github.event_name != 'pull_request' }}
+        if: ${{ failure() && github.event_name != 'pull_request' && inputs.notify-slack }}
         uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,6 +19,10 @@ on:
         description: 'Stack distribution (default | oss). Passed through to the setup action as the DISTRIBUTION env var.'
         type: string
         default: 'default'
+      notify-slack:
+        description: 'Send a Slack notification on failure.'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -61,7 +65,7 @@ jobs:
         run: bash .ci/docker-run.sh
 
       - name: Notify Slack on failure
-        if: ${{ failure() && github.event_name != 'pull_request' }}
+        if: ${{ failure() && github.event_name != 'pull_request' && inputs.notify-slack }}
         uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Add a way to "stop" a slack notification. This makes the default to send. Plugins can over ride this by setting the new input to false.
